### PR TITLE
Add virtual ~Token::Token()

### DIFF
--- a/src/markdown-tokens.h
+++ b/src/markdown-tokens.h
@@ -42,6 +42,7 @@ class LinkIds {
 class Token {
 	public:
 	Token() { }
+	virtual ~Token() { }
 
 	virtual void writeAsHtml(std::ostream&) const=0;
 	virtual void writeAsOriginal(std::ostream& out) const { writeAsHtml(out); }


### PR DESCRIPTION
Polymorphic classes must have a virtual destructor. Otherwise, deleting an object of a derived class through a base-class pointer is undefined behavior.
