### PR TITLE
Make all arguments have a name and mark unused ones with MD_UNUSED

### DIFF
--- a/src/markdown-tokens.h
+++ b/src/markdown-tokens.h
@@ -43,7 +43,7 @@ class Token {
 	public:
 	Token() { }
 
-	virtual void writeAsHtml(std::ostream&) const=0;
+	virtual void writeAsHtml(std::ostream& out) const=0;
 	virtual void writeAsOriginal(std::ostream& out) const { writeAsHtml(out); }
 	virtual void writeToken(std::ostream& out) const=0;
 	virtual void writeToken(size_t indent, std::ostream& out) const {
@@ -66,8 +66,8 @@ class Token {
 	virtual bool inhibitParagraphs() const { return false; }
 
 	protected:
-	virtual void preWrite(std::ostream& out) const { }
-	virtual void postWrite(std::ostream& out) const { }
+	virtual void preWrite(std::ostream& out) const { MD_UNUSED(out); }
+	virtual void postWrite(std::ostream& out) const { MD_UNUSED(out); }
 };
 
 namespace token {

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -566,6 +566,8 @@ optional<TokenPtr> parseHeader(CTokenGroupIter& i, CTokenGroupIter end) {
 }
 
 optional<TokenPtr> parseHorizontalRule(CTokenGroupIter& i, CTokenGroupIter end) {
+	MD_UNUSED(end);
+
 	if (!(*i)->isBlankLine() && (*i)->text() && (*i)->canContainMarkup()) {
 		static const boost::regex cHorizontalRules("^ {0,3}((?:-|\\*|_) *){3,}$");
 		const std::string& line=*(*i)->text();

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -17,6 +17,8 @@
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#define MD_UNUSED(x) (void)x
+
 namespace markdown {
 
 	using boost::optional;
@@ -38,10 +40,10 @@ namespace markdown {
 		// You can call read() functions multiple times before writing if
 		// desirable. Once the document has been processed for writing, it can't
 		// accept any more input.
-		bool read(const std::string&);
-		bool read(std::istream&);
-		void write(std::ostream&);
-		void writeTokens(std::ostream&); // For debugging
+		bool read(const std::string& src);
+		bool read(std::istream& in);
+		void write(std::ostream& out);
+		void writeTokens(std::ostream& out); // For debugging
 
 		// The class is marked noncopyable because it uses reference-counted
 		// links to things that get changed during processing. If you want to


### PR DESCRIPTION
"idTable" and "out" have been completely removed because the types are self-documenting. "end" has been commented out to document its contents.
