### PR TITLE
Add basic CMakeFile.txt for easy compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8)
+project(cpp-markdown)
+
+add_library(cppmarkdown
+	src/markdown.h
+	src/markdown.cpp
+	src/markdown-tokens.h
+	src/markdown-tokens.cpp
+)
+target_include_directories(cppmarkdown PUBLIC src)
+target_link_libraries(cppmarkdown PUBLIC boost_regex)
+
+add_executable(cpp-markdown src/main.cpp)
+target_link_libraries(cpp-markdown PUBLIC cppmarkdown)
+


### PR DESCRIPTION
If someone just wants to build the executable, it is great to have a
simple procedure such as running `cmake . && make`

Additionally, you can include this into your own CMake-based project by
using `add_subdirectory(/path/to/cpp-markdown)` and then
`target_link_libraries(your_target PUBLIC cppmarkdown)`, which will use
the CMake settings (including CXXFLAGS etc.) from the parent project and
auto-configure include and link paths.
